### PR TITLE
fixes #55 DNS1 & DNS2 bug

### DIFF
--- a/alpine/start.sh
+++ b/alpine/start.sh
@@ -4,8 +4,6 @@
 export IMAGE
 export ServerIP
 export ServerIPv6
-export DNS1
-export DNS2
 export PYTEST
 export PHP_ENV_CONFIG
 export PHP_ERROR_LOG 
@@ -13,7 +11,7 @@ export PHP_ERROR_LOG
 validate_env
 setup_saved_variables
 setup_php_env
-setup_dnsmasq
+setup_dnsmasq "$DNS1" "$DNS2"
 
 # alpine unique currently
 ip_versions="IPv4 and IPv6"

--- a/common_start.sh
+++ b/common_start.sh
@@ -13,9 +13,9 @@ setup_saved_variables() {
 }
 
 setup_dnsmasq() {
-    local dnsType='default'
     local DNS1="${1:-8.8.8.8}"
     local DNS2="${2:-8.8.4.4}"
+    local dnsType='default'
     if [ "$DNS1" != '8.8.8.8' ] || [ "$DNS2" != '8.8.4.4' ] ; then
       dnsType='custom'
     fi;

--- a/debian/start.sh
+++ b/debian/start.sh
@@ -4,8 +4,6 @@
 export IMAGE
 export ServerIP
 export ServerIPv6
-export DNS1
-export DNS2
 export PYTEST
 export PHP_ENV_CONFIG
 export PHP_ERROR_LOG 
@@ -13,7 +11,7 @@ export PHP_ERROR_LOG
 validate_env
 setup_saved_variables
 setup_php_env
-setup_dnsmasq
+setup_dnsmasq "$DNS1" "$DNS2"
 test_configs
 test_framework_stubbing
 

--- a/test/test_start.py
+++ b/test/test_start.py
@@ -69,3 +69,20 @@ def test_admin_requests_load_as_expected(RunningPiHole, ip, url):
     assert RunningPiHole.run('wc -l /tmp/curled_file ') > 10
     assert RunningPiHole.run('grep -q "Content-Security-Policy" /tmp/curled_file ').rc == 0
     assert RunningPiHole.run('grep -q "js/pihole/footer.js" /tmp/curled_file ').rc == 0
+
+@pytest.mark.parametrize('args, expected_stdout, dns1, dns2', [
+    ('-e ServerIP="1.2.3.4"', 'default DNS', '8.8.8.8', '8.8.4.4' ),
+    ('-e ServerIP="1.2.3.4" -e DNS1="1.2.3.4"', 'custom DNS', '1.2.3.4', '8.8.4.4' ),
+    ('-e ServerIP="1.2.3.4" -e DNS2="1.2.3.4"', 'custom DNS', '8.8.8.8', '1.2.3.4' ),
+    ('-e ServerIP="1.2.3.4" -e DNS1="1.2.3.4" -e DNS2="2.2.3.4"', 'custom DNS', '1.2.3.4', '2.2.3.4' ),
+])
+@pytest.mark.parametrize('cmd', [ 'tail -f /dev/null' ])
+def test_DNS_Envs_override_defaults(Docker, args, expected_stdout, dns1, dns2):
+    ''' When DNS environment vars are passed in, they override default dns servers '''
+    run_function = Docker.run('. /common_start.sh ; eval `grep setup_dnsmasq /start.sh`')
+    assert expected_stdout in run_function.stdout
+
+    docker_dns_servers = Docker.run('grep "^server=" /etc/dnsmasq.d/01-pihole.conf').stdout
+    expected_servers = 'server={}\nserver={}\n'.format(dns1, dns2)
+    print expected_servers, '==', docker_dns_servers
+    assert expected_servers == docker_dns_servers

--- a/test/test_start.py
+++ b/test/test_start.py
@@ -55,7 +55,6 @@ def test_html_index_requests_load_as_expected(RunningPiHole, ip, url):
 @pytest.mark.parametrize('url', [ '/index.js', '/any.js'] )
 def test_javascript_requests_load_as_expected(RunningPiHole, ip, url):
     command = 'curl -s -o /tmp/curled_file -w "%{{http_code}}" http://{}{}'.format(ip, url)
-    print command
     http_rc = RunningPiHole.run(command)
     assert RunningPiHole.run('md5sum /tmp/curled_file /var/www/html/pihole/index.js').rc == 0
     assert int(http_rc.stdout) == 200
@@ -84,5 +83,4 @@ def test_DNS_Envs_override_defaults(Docker, args, expected_stdout, dns1, dns2):
 
     docker_dns_servers = Docker.run('grep "^server=" /etc/dnsmasq.d/01-pihole.conf').stdout
     expected_servers = 'server={}\nserver={}\n'.format(dns1, dns2)
-    print expected_servers, '==', docker_dns_servers
     assert expected_servers == docker_dns_servers


### PR DESCRIPTION
- tests now watch for regression in these ENV var's behavior
- use local scope in function instead of exported for easier testing