### PR TITLE
Tini update and arm version

### DIFF
--- a/alpine.docker
+++ b/alpine.docker
@@ -3,13 +3,21 @@ MAINTAINER adam@diginc.us <adam@diginc.us>
 
 ENV IMAGE alpine
 
-RUN apk add --update \
+ENV TINI_VERSION v0.13.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static.asc /tini.asc
+
+# Tini and package requirements
+RUN apk add --update gpgme && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0527A9B7 && \
+    gpg --verify /tini.asc && \
+    chmod +x /tini && \
+    apk add \
         dnsmasq \
         nginx \
         ca-certificates \
         php5-fpm php5-json php5-openssl libxml2 \
-        bc bash curl perl sudo && \
-    apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/testing/ tini && \
+        bc bash curl perl sudo git && \
     rm -rf /var/cache/apk/*
 
 # Customized from submodules
@@ -76,5 +84,5 @@ ENV IPv6 True
 EXPOSE 53 53/udp
 EXPOSE 80
 
-ENTRYPOINT ["tini", "--"]
-CMD /start.sh
+ENTRYPOINT ["/tini", "--"]
+CMD [ "/start.sh" ]

--- a/debian-armhf.docker
+++ b/debian-armhf.docker
@@ -4,14 +4,21 @@ MAINTAINER adam@diginc.us <adam@diginc.us>
 RUN [ "cross-build-start" ]
 ENV IMAGE debian
 
-# Requirements
-RUN apt-get -q update && \
+ENV TINI_VERSION v0.13.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-armhf /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-armhf.asc /tini.asc
+
+# Tini and package requirements
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0527A9B7 && \
+    gpg --verify /tini.asc && \
+    chmod +x /tini && \
+    apt-get -q update && \
     apt-get install -y \
         dnsmasq \
         lighttpd \
         php5-common php5-cgi php5 \
         bc curl unzip wget sudo dnsutils && \
-    rm -rf /var/cache/apt/archives
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Original upstream pihole code being used
 COPY ./pi-hole/gravity.sh /usr/local/bin/
@@ -70,7 +77,7 @@ EXPOSE 53 53/udp
 EXPOSE 80
 
 # Tini doesn't work in ARM
-ENTRYPOINT [ "bash", "-c" ]
+ENTRYPOINT ["/tini", "--"]
 CMD [ "/start.sh" ]
 
 RUN [ "cross-build-end" ]  

--- a/debian.docker
+++ b/debian.docker
@@ -3,21 +3,21 @@ MAINTAINER adam@diginc.us <adam@diginc.us>
 
 ENV IMAGE debian
 
-ENV TINI_VERSION v0.10.0
+ENV TINI_VERSION v0.13.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0527A9B7 \
- && gpg --verify /tini.asc
-RUN chmod +x /tini
 
-# Requirements
-RUN apt-get -q update && \
+# Tini and package requirements
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0527A9B7 && \
+    gpg --verify /tini.asc && \
+    chmod +x /tini && \
+    apt-get -q update && \
     apt-get install -y \
         dnsmasq \
         lighttpd \
         php5-common php5-cgi php5 \
         bc curl unzip wget sudo dnsutils && \
-    rm -rf /var/cache/apt/archives
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Original upstream pihole code being used
 COPY ./pi-hole/gravity.sh /usr/local/bin/
@@ -76,4 +76,4 @@ EXPOSE 53 53/udp
 EXPOSE 80
 
 ENTRYPOINT ["/tini", "--"]
-CMD /start.sh
+CMD [ "/start.sh" ]


### PR DESCRIPTION
* Noticed:
  * tini arm is out!  Go ARM TINI - thanks @krallin
  * tini alpine is behind on 0.9 - grabbed latest the same way as debians
  * Redundant run steps between requirements and tini, merged
  * inconsistency in dockerfiles, made consistent
  * I kept writing noticed in front of all these items, used nesting instead