### PR TITLE
Ensure DNS is available early

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -153,17 +153,20 @@ test_framework_stubbing() {
 }
 
 main() {
+    echo -n '::: Starting up DNS and Webserver ...'
+    pihole restartdns # Just get DNS up. The webserver is down!!!
+
     IMAGE="$1"
-    case $IMAGE in
+    case $IMAGE in # Setup webserver
         "alpine")
-             gravity.sh # dnsmasq start included
-             php-fpm
-             nginx
+            php-fpm
+            nginx
         ;;
         "debian")
-             gravity.sh # dnsmasq start included
-             service lighttpd start
+            service lighttpd start
         ;;
     esac
+
+    gravity.sh # Finally lets update and be awesome.
     tail -F "${WEBLOGDIR}"/*.log /var/log/pihole.log
 }

--- a/test/test_pihole_scripts.py
+++ b/test/test_pihole_scripts.py
@@ -1,22 +1,22 @@
 import pytest
 
 @pytest.fixture
-def restart_cmd():
+def start_cmd():
     ''' broken by default, required override '''
     return None
 
-RESTART_DNS_STDOUT = {
+START_DNS_STDOUT = {
     'alpine': '',
-    'debian': 'Restarting DNS forwarder and DHCP server: dnsmasq.\n'
+    'debian': 'Starting DNS forwarder and DHCP server: dnsmasq.\n'
 }
 @pytest.fixture
-def RunningPiHole(DockerPersist, Slow, persist_webserver, persist_tag, restart_cmd):
+def RunningPiHole(DockerPersist, Slow, persist_webserver, persist_tag, start_cmd):
     ''' Override the RunningPiHole to run and check for success of a
-        dnsmasq restart based `pihole` script command '''
+        dnsmasq start based `pihole` script command '''
     Slow(lambda: DockerPersist.run('pgrep {}'.format(persist_webserver) ).rc == 0)
     Slow(lambda: DockerPersist.run('pgrep dnsmasq').rc == 0)
     oldpid = DockerPersist.run('pidof dnsmasq')
-    cmd = DockerPersist.run('pihole {}'.format(restart_cmd))
+    cmd = DockerPersist.run('pihole {}'.format(start_cmd))
     Slow(lambda: DockerPersist.run('pgrep dnsmasq').rc == 0)
     newpid = DockerPersist.run('pidof dnsmasq')
     for pid in [oldpid, newpid]:
@@ -24,24 +24,24 @@ def RunningPiHole(DockerPersist, Slow, persist_webserver, persist_tag, restart_c
     # ensure a new pid for dnsmasq appeared
     assert oldpid != newpid
     assert cmd.rc == 0
-    # Save out cmd result to check different stdout of restart/enable/disable
+    # Save out cmd result to check different stdout of start/enable/disable
     DockerPersist.cmd = cmd
     return DockerPersist
 
-@pytest.mark.parametrize('restart_cmd', ['restart_cmd'])
-def test_pihole_restart_cmd(RunningPiHole, restart_cmd, persist_tag):
-    ''' the restart_cmd tests are all built into the RunningPiHole fixture in this file '''
-    assert RunningPiHole.cmd.stdout == RESTART_DNS_STDOUT[persist_tag]
+@pytest.mark.parametrize('start_cmd', ['start_cmd'])
+def test_pihole_start_cmd(RunningPiHole, start_cmd, persist_tag):
+    ''' the start_cmd tests are all built into the RunningPiHole fixture in this file '''
+    assert RunningPiHole.cmd.stdout == START_DNS_STDOUT[persist_tag]
 
-@pytest.mark.parametrize('restart_cmd,hostname,expected_ip', [
+@pytest.mark.parametrize('start_cmd,hostname,expected_ip', [
     ('enable',  'pi.hole', '192.168.100.2'),
     ('disable', 'pi.hole', '192.168.100.2'),
 ])
-def test_pihole_restart_cmd(RunningPiHole, Dig, persist_tag, restart_cmd, hostname, expected_ip):
-    ''' the restart_cmd tests are all built into the RunningPiHole fixture in this file '''
+def test_pihole_start_cmd(RunningPiHole, Dig, persist_tag, start_cmd, hostname, expected_ip):
+    ''' the start_cmd tests are all built into the RunningPiHole fixture in this file '''
     dig_cmd = "dig +time=1 +noall +answer {} @test_pihole | awk '{{ print $5 }}'".format(hostname)
     lookup = RunningPiHole.dig.run(dig_cmd).stdout.rstrip('\n')
     assert lookup == expected_ip
 
-    stdout = "::: Blocking has been {}d!\n{}".format(restart_cmd, RESTART_DNS_STDOUT[persist_tag])
+    stdout = "::: Blocking has been {}d!\n{}".format(start_cmd, START_DNS_STDOUT[persist_tag])
     assert RunningPiHole.cmd.stdout == stdout


### PR DESCRIPTION
This change brings up dnsmasq early without relying on gravity update.  If dnsmasq is NOT started before gravity updates then it could be as long as the number of blocklist sources multiplied by 2m(timeout). Ie any of the blocklists being down could greatly effect the availability of the pi.hole service. 

This can be especially problematic if there are health checks running against the container... for example rancher/k8s etc... may reschedule the container after failing health checks :(

