### PR TITLE
Hotfix php-fpm5 binary for old version

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -170,7 +170,7 @@ test_configs_alpine() {
     echo -n '::: Testing DNSmasq config: '
     dnsmasq --test -7 /etc/dnsmasq.d
     echo -n '::: Testing PHP-FPM config: '
-    php-fpm -t
+    php-fpm5 -t
     echo -n '::: Testing NGINX config: '
     nginx -t
     set +e
@@ -188,7 +188,7 @@ docker_main() {
     IMAGE="$1"
     case $IMAGE in # Setup webserver
         "alpine")
-            php-fpm
+            php-fpm5
             nginx
         ;;
         "debian")


### PR DESCRIPTION
Fixes #127

Sorry, I had to rebuild the newest tag to re-release the readme to docker hub/store and the re-build broke things.