### PR TITLE
Bind lighttpd to only one IP when using "--net=host"

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -119,16 +119,16 @@ setup_dnsmasq_hostnames() {
 }
 
 setup_lighttpd_bind() {
-if [[ "$IMAGE" == 'debian' ]] ; then
-	# if using '--net=host' only bing lighttpd on $ServerIP
-	HOSTNET='grep "docker" /proc/net/dev/' #docker (docker0 by default) should only be present on the host system
-	if [ -n "$HOSTNET" ] ; then
-		if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
-		then
-			sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
+	if [[ "$IMAGE" == 'debian' ]] ; then
+		# if using '--net=host' only bing lighttpd on $ServerIP
+		HOSTNET='grep "docker" /proc/net/dev' #docker (docker0 by default) should only be present on the host system
+		if [ -n "$HOSTNET" ] ; then
+			if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
+			then
+				sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
+			fi
 		fi
 	fi
-fi
 }
 
 setup_php_env() {

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -119,16 +119,14 @@ setup_dnsmasq_hostnames() {
 }
 
 setup_lighttpd_bind() {
-	if [[ "$IMAGE" == 'debian' ]] ; then
-		# if using '--net=host' only bing lighttpd on $ServerIP
-		HOSTNET='grep "docker" /proc/net/dev' #docker (docker0 by default) should only be present on the host system
-		if [ -n "$HOSTNET" ] ; then
-			if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
-			then
-				sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
-			fi
-		fi
-	fi
+    if [[ "$IMAGE" == 'debian' ]] ; then
+    # if using '--net=host' only bind lighttpd on $ServerIP
+        if grep -q "docker" /proc/net/dev ; then #docker (docker0 by default) should only be present on the host system
+            if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf ; then # if the declaration is already there, don't add it again
+                sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
+            fi
+        fi
+    fi
 }
 
 setup_php_env() {

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -118,6 +118,19 @@ setup_dnsmasq_hostnames() {
     fi
 }
 
+setup_lighttpd_bind() {
+if [[ "$IMAGE" == 'debian' ]] ; then
+	# if using '--net=host' only bing lighttpd on $ServerIP
+	HOSTNET='grep "docker" /proc/net/dev/' #docker (docker0 by default) should only be present on the host system
+	if [ -n "$HOSTNET" ] ; then
+		if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
+		then
+			sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
+		fi
+	fi
+fi
+}
+
 setup_php_env() {
     case $IMAGE in
         "debian") setup_php_env_debian ;;

--- a/start.sh
+++ b/start.sh
@@ -25,17 +25,7 @@ setup_dnsmasq
 setup_php_env
 setup_dnsmasq_hostnames "$ServerIP" "$ServerIPv6" "$HOSTNAME"
 setup_ipv4_ipv6
-if [[ "$IMAGE" == 'debian' ]] ; then
-	# if using '--net=host' only bing lighttpd on $ServerIP
-	HOSTNET='grep "docker" /proc/net/dev/' #docker (docker0 by default) should only be present on the host system
-	if [ -n "$HOSTNET" ] ; then
-		if ! grep "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
-		then
-			sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
-		fi
-	fi
-fi
-
+setup_lighttpd_bind "$ServerIP" "$IMAGE"
 test_configs
 test_framework_stubbing
 echo "::: Docker start setup complete - beginning s6 services"

--- a/start.sh
+++ b/start.sh
@@ -25,6 +25,17 @@ setup_dnsmasq
 setup_php_env
 setup_dnsmasq_hostnames "$ServerIP" "$ServerIPv6" "$HOSTNAME"
 setup_ipv4_ipv6
+if [[ "$IMAGE" == 'debian' ]] ; then
+	# if using '--net=host' only bing lighttpd on $ServerIP
+	HOSTNET='grep "docker" /proc/net/dev/' #docker (docker0 by default) should only be present on the host system
+	if [ -n "$HOSTNET" ] ; then
+		if ! grep "server.bind" /etc/lighttpd/lighttpd.conf # if the declaration is already there, don't add it again
+		then
+			sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80/" /etc/lighttpd/lighttpd.conf
+		fi
+	fi
+fi
+
 test_configs
 test_framework_stubbing
 echo "::: Docker start setup complete - beginning s6 services"


### PR DESCRIPTION
See #154. 

This only applies to the Debian image.  I imagine it would be possible to do something similar for nginx on the Alpine image, though. 