### PR TITLE
Fix passing in DNS1 and DNS2 env vars to setup_dnsmasq

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,7 @@ prepare_setup_vars
 change_setting "IPV4_ADDRESS" "$ServerIP"
 change_setting "IPV6_ADDRESS" "$ServerIPv6"
 setup_web_password "$WEBPASSWORD"
-setup_dnsmasq
+setup_dnsmasq "$DNS1" "$DNS2"
 setup_php_env
 setup_dnsmasq_hostnames "$ServerIP" "$ServerIPv6" "$HOSTNAME"
 setup_ipv4_ipv6


### PR DESCRIPTION
Noticed that DNS1 and DNS2 env variables were not being picked up by pihole. Discovered this while trying to debug why my custom DNS set in the web admin was being reset every time the container restarted. 