### PR TITLE
Fix "wrong domain bug" on block page

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,8 +77,8 @@ sed -i 's/readonly //g' /opt/pihole/webpage.sh
 if [[ "$IMAGE" == 'alpine' ]] ; then
 	cp /etc/.pihole/advanced/pihole.cron /etc/crontabs/pihole
 	
-	# Fix hostname bug on block page
-    sed -i "s/\(\$_SERVER\['SERVER_NAME'\]\)/\(\$_SERVER\['HTTP_HOST'\]\)/" /var/www/html/pihole/index.php
+    # Fix hostname bug on block page
+    sed -i "s/\$_SERVER\['SERVER_NAME'\]/\$_SERVER\['HTTP_HOST'\]/" /var/www/html/pihole/index.php
 fi
  
 

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,9 @@ installPihole | tee "${tmpLog}"
 sed -i 's/readonly //g' /opt/pihole/webpage.sh
 if [[ "$IMAGE" == 'alpine' ]] ; then
 	cp /etc/.pihole/advanced/pihole.cron /etc/crontabs/pihole
+	
+	# Fix hostname bug on block page
+    sed -i "s/\(\$_SERVER\['SERVER_NAME'\]\)/\(\$_SERVER\['HTTP_HOST'\]\)/" /var/www/html/pihole/index.php
 fi
  
 


### PR DESCRIPTION
This fixes issue #156 which says that on the block page, at least on alpine linux display the wrong domain which makes easy whitelisting not possible.