### PR TITLE
fail container if start.sh fails

### DIFF
--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
+set -e
 
 # Early DNS Startup for the gravity list process to use
 dnsmasq -7 /etc/dnsmasq.d


### PR DESCRIPTION
stop the container whenever start.sh exits with exit status != 0

# motivation

I had a bogus IPv6 address set in my environment variables. It took me quite a while to realize my `DNS1` and `DNS2` environment variables where ignored by pi-hole.
The fact that the container continued its starting process despite start.sh exiting with exit status 1 made me ignore the error messages in the starting log.

This PR changes the starting behavior so that the pi-hole container will exits whenever start.sh fails. That way, as soon as we mess our config up, the issue won't remain unnoticed.

# tests

I did run `tox` and had a few errors, but running `tox` from the master branch also had a few errors. So I'm not sure whether that change had an impact or not.