### PR TITLE
Attempting to update base image to debian stretch

### DIFF
--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -40,15 +40,15 @@ os_base_vars = {
 images = {
     'debian': [
         {
-            'base': 'debian:jessie',
+            'base': 'debian:stretch',
             'arch': 'amd64'
         },
         {
-            'base': 'multiarch/debian-debootstrap:armhf-jessie-slim',
+            'base': 'multiarch/debian-debootstrap:armhf-stretch-slim',
             'arch': 'armhf'
         },
         {
-            'base': 'multiarch/debian-debootstrap:arm64-jessie-slim',
+            'base': 'multiarch/debian-debootstrap:arm64-stretch-slim',
             'arch': 'aarch64'
         }
     ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,7 @@ LABEL image="{{ pihole.name }}:{{ pihole.os }}_{{ pihole.arch }}"
 LABEL maintainer="{{ pihole.maintainer }}"
 LABEL url="https://www.github.com/diginc/docker-pi-hole"
 
+ARG DEBIAN_FRONTED=noninteractive
 ENV TAG {{ pihole.os }}
 ENV ARCH {{ pihole.arch }}
 ENV PATH /opt/pihole:${PATH}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,7 @@ ENV PIHOLE_INSTALL /tmp/ph_install.sh
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/{{ pihole.s6_version }}/s6-overlay-{{ pihole.arch }}.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y wget curl net-tools cron && \
+    apt-get install -y wget curl net-tools cron procps && \
     curl -L -s $S6OVERLAY_RELEASE \
         | tar xvzf - -C / && \
     docker-install.sh && \

--- a/Dockerfile_debian_aarch64
+++ b/Dockerfile_debian_aarch64
@@ -1,9 +1,10 @@
-FROM multiarch/debian-debootstrap:arm64-jessie-slim
+FROM multiarch/debian-debootstrap:arm64-stretch-slim
 
 LABEL image="diginc/pi-hole:debian_aarch64"
 LABEL maintainer="adam@diginc.us"
 LABEL url="https://www.github.com/diginc/docker-pi-hole"
 
+ARG DEBIAN_FRONTED=noninteractive
 ENV TAG debian
 ENV ARCH aarch64
 ENV PATH /opt/pihole:${PATH}
@@ -14,7 +15,7 @@ ENV PIHOLE_INSTALL /tmp/ph_install.sh
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.2.2/s6-overlay-aarch64.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y wget curl net-tools cron && \
+    apt-get install -y wget curl net-tools cron procps && \
     curl -L -s $S6OVERLAY_RELEASE \
         | tar xvzf - -C / && \
     docker-install.sh && \

--- a/Dockerfile_debian_amd64
+++ b/Dockerfile_debian_amd64
@@ -1,9 +1,10 @@
-FROM debian:jessie
+FROM debian:stretch
 
 LABEL image="diginc/pi-hole:debian_amd64"
 LABEL maintainer="adam@diginc.us"
 LABEL url="https://www.github.com/diginc/docker-pi-hole"
 
+ARG DEBIAN_FRONTED=noninteractive
 ENV TAG debian
 ENV ARCH amd64
 ENV PATH /opt/pihole:${PATH}
@@ -14,7 +15,7 @@ ENV PIHOLE_INSTALL /tmp/ph_install.sh
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.2.2/s6-overlay-amd64.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y wget curl net-tools cron && \
+    apt-get install -y wget curl net-tools cron procps && \
     curl -L -s $S6OVERLAY_RELEASE \
         | tar xvzf - -C / && \
     docker-install.sh && \

--- a/Dockerfile_debian_armhf
+++ b/Dockerfile_debian_armhf
@@ -1,9 +1,10 @@
-FROM multiarch/debian-debootstrap:armhf-jessie-slim
+FROM multiarch/debian-debootstrap:armhf-stretch-slim
 
 LABEL image="diginc/pi-hole:debian_armhf"
 LABEL maintainer="adam@diginc.us"
 LABEL url="https://www.github.com/diginc/docker-pi-hole"
 
+ARG DEBIAN_FRONTED=noninteractive
 ENV TAG debian
 ENV ARCH armhf
 ENV PATH /opt/pihole:${PATH}
@@ -14,7 +15,7 @@ ENV PIHOLE_INSTALL /tmp/ph_install.sh
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.2.2/s6-overlay-armhf.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y wget curl net-tools cron && \
+    apt-get install -y wget curl net-tools cron procps && \
     curl -L -s $S6OVERLAY_RELEASE \
         | tar xvzf - -C / && \
     docker-install.sh && \

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,9 @@ export USE_DEVELOPMENT_BRANCHES=false
 #     Make pihole scripts fail searching for `systemctl`,
 # which fails pretty miserably in docker compared to `service`
 # For more info see docker/docker issue #7459
-mv "$(which systemctl)" /bin/no_systemctl && \
+which systemctl && mv "$(which systemctl)" /bin/no_systemctl
 # debconf-apt-progress seems to hang so get rid of it too
-mv "$(which debconf-apt-progress)" /bin/no_debconf-apt-progress
+which which debconf-apt-progress && mv "$(which debconf-apt-progress)" /bin/no_debconf-apt-progress
 
 # Get the install functions
 wget -O "$PIHOLE_INSTALL" https://raw.githubusercontent.com/pi-hole/pi-hole/${CORE_TAG}/automated%20install/basic-install.sh


### PR DESCRIPTION
This is mostly to fix https://github.com/pi-hole/pi-hole/issues/1392 for me, which shows we need a more modern version of dnsmasq.
the one in jessie is a couple years old now.

I am not sure if I should be updating the docker templates, but they were in the branch to start with