### PR TITLE
fix IP V6 lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ One crucial thing to know before starting is this container needs port 53 and po
 
 ```
 IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{ print $NF; exit }')"  # May not work for VPN / tun0
-IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{ print $10; exit }')"  # May not work for VPN / tun0
+IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  # May not work for VPN / tun0
 IP="${IP:-$IP_LOOKUP}"  # use $IP, if set, otherwise IP_LOOKUP
 IPv6="${IPv6:-$IPv6_LOOKUP}"  # use $IPv6, if set, otherwise IP_LOOKUP
 DOCKER_CONFIGS="$(pwd)"  # Default of directory you run this from, update to where ever.

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{ print $NF; exit }')"  # May not work for VPN / tun0
-IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{ print $10; exit }')"  # May not work for VPN / tun0
+IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  # May not work for VPN / tun0
 IP="${IP:-$IP_LOOKUP}"  # use $IP, if set, otherwise IP_LOOKUP
 IPv6="${IPv6:-$IPv6_LOOKUP}"  # use $IPv6, if set, otherwise IP_LOOKUP
 DOCKER_CONFIGS="$(pwd)"  # Default of directory you run this from, update to where ever.


### PR DESCRIPTION
Forgot to add the lookup fix from https://github.com/diginc/docker-pi-hole/issues/199#issuecomment-372462890

<!--- Provide a general summary of your changes in the Title above -->

## Description
The origional IPv6 lookup command in the readme/start script was naive in beliving the IP would have a somewhat static column position.  It seems to vary by OS distribution but it always has 'src' in front so this awk command looks for src column +1

## Motivation and Context
Better IPv6 user experience

## How Has This Been Tested?
- Pipe cmd was tested with the output ipv6 commands.
- Not fully tested until travis runs (editing on web)
- I do not have IPv6 setup properly on my network so I suck at dog fooding the IPv6 feature, help appreciated in testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
