### PR TITLE
Fixed malformed lighthttpd.conf when using host networking and setting WEB_PORT. Fixes #247

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -135,7 +135,7 @@ setup_lighttpd_bind() {
     # if using '--net=host' only bind lighttpd on $ServerIP and localhost
         if grep -q "docker" /proc/net/dev ; then #docker (docker0 by default) should only be present on the host system
             if ! grep -q "server.bind" /etc/lighttpd/lighttpd.conf ; then # if the declaration is already there, don't add it again
-                sed -i -E "s/server\.port\s+\=\s+80/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = 80\n"\$SERVER"\[\"socket\"\] == \"127\.0\.0\.1:80\" \{\}/" /etc/lighttpd/lighttpd.conf
+                sed -i -E "s/server\.port\s+\=\s+([0-9]+)/server.bind\t\t = \"${ServerIP}\"\nserver.port\t\t = \1\n"\$SERVER"\[\"socket\"\] == \"127\.0\.0\.1:\1\" \{\}/" /etc/lighttpd/lighttpd.conf
             fi
         fi
     fi


### PR DESCRIPTION
## Description
Fixes the modification of lighthttpd.conf to preserve the custom port set by WEB_PORT.

## Motivation and Context
Fixes #247 

## How Has This Been Tested?
Tested on local diginc/docker-pi-hole instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
