### PR TITLE
Fail container on error in start.sh

### DIFF
--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv bash
 set
+set -e
 
 bashCmd='bash -e'
 if [ "${PH_VERBOSE:-0}" -gt 0 ] ; then 

--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
-set
 set -e
 
 bashCmd='bash -e'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fail the container if a error in the start.sh occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the container is started with work parameters or something is going wrong in the start.sh the container regardleas spins up. This can result into direct errors or errors longer down the way. 
For example 
`docker run --rm -v "$(pwd)/dnsmasq.d/:/etc/dnsmasq.d/" pi-hole-multiarch:debian_armhf` result into a running container and creates a `01-pihole.conf` with only `addn-hosts=/etc/pihole/gravity.list` as content. This results into missing log entries and no stats. See #272 and #241. Possible are other problems.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Run the image without an ServerIP and with an ServerIP environment variable. Without ServerIP the container now fails and with an ServerIP the container spins up.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
