### PR TITLE
allow no for DNS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are other environment variables if you want to customize various things in
 | `-e TZ=<Timezone>`<br/> **Recommended** *Default: UTC* | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `-e WEBPASSWORD=<Admin password>`<br/> **Recommended** *Default: random* | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
 | `-e DNS1=<IP>`<br/> *Optional* *Default: 8.8.8.8* | Primary upstream DNS provider, default is google DNS
-| `-e DNS2=<IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS
+| `-e DNS2=<IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used
 | `-e VIRTUAL_HOST=<Custom Hostname>`<br/> *Optional* *Default: $ServerIP*   | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address
 | `-e IPv6=<True\|False>`<br/> *Optional* *Default: True* | For unraid compatibility, strips out all the IPv6 configuration from DNS/Web services when false.
 | `-e INTERFACE=<NIC>`<br/> *Advanced/Optional* | The default works fine with our basic example docker run commands.  If you're trying to use DHCP with `--net host` mode then you may have to customize this or DNSMASQ_LISTENING.

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -63,7 +63,11 @@ setup_dnsmasq_dns() {
         change_setting "PIHOLE_DNS_1" "${DNS1}"
     fi
     if [[ -n "$DNS2" && -z "$setupDNS2" ]] ; then
-        change_setting "PIHOLE_DNS_2" "${DNS2}"
+        if [ "$DNS2" = "no" ] ; then
+            delete_setting "PIHOLE_DNS_2"
+        else
+            change_setting "PIHOLE_DNS_2" "${DNS2}"
+        fi
     fi
 }
 

--- a/test/test_bash_functions.py
+++ b/test/test_bash_functions.py
@@ -55,6 +55,8 @@ def test_bad_input_to_WEB_PORT(Docker, args, expected_error):
     ('-e ServerIP="1.2.3.4" -e DNS1="1.2.3.4"',                   'custom DNS',  '1.2.3.4', '8.8.4.4' ),
     ('-e ServerIP="1.2.3.4" -e DNS2="1.2.3.4"',                   'custom DNS',  '8.8.8.8', '1.2.3.4' ),
     ('-e ServerIP="1.2.3.4" -e DNS1="1.2.3.4" -e DNS2="2.2.3.4"', 'custom DNS',  '1.2.3.4', '2.2.3.4' ),
+    ('-e ServerIP="1.2.3.4" -e DNS1="1.2.3.4" -e DNS2="no"', 'custom DNS',  '1.2.3.4', None ),
+    ('-e ServerIP="1.2.3.4" -e DNS2="no"', 'custom DNS',  '8.8.8.8', None ),
 ])
 def test_override_default_servers_with_DNS_EnvVars(Docker, args, expected_stdout, dns1, dns2):
     ''' on first boot when DNS vars are NOT set explain default google DNS settings are used
@@ -64,7 +66,7 @@ def test_override_default_servers_with_DNS_EnvVars(Docker, args, expected_stdout
     assert expected_stdout in function.stdout
 
     docker_dns_servers = Docker.run('grep "^server=" /etc/dnsmasq.d/01-pihole.conf').stdout
-    expected_servers = 'server={}\nserver={}\n'.format(dns1, dns2)
+    expected_servers = 'server={}\n'.format(dns1) if dns2 == None else 'server={}\nserver={}\n'.format(dns1, dns2)
     assert expected_servers == docker_dns_servers
 
 @pytest.mark.parametrize('args, dns1, dns2, expected_stdout', [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows to have only a single DNS Server and not default to the second Google DNS.
<!--- Describe your changes in detail -->

## Motivation and Context
Resolves #281 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Run py.test on armhf (raspberry pi 3) with the new tests and run the container with DNS2 `no` and with DNS2 with the value `1.1.1.1`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
